### PR TITLE
Add sandbox for puppeteer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: node_js
-sudo: false
+sudo: required
+addons:
+ chrome: stable
 node_js:
   - "9.2.1"
 install:

--- a/browser-tests/calender-test.js
+++ b/browser-tests/calender-test.js
@@ -10,7 +10,7 @@ describe('Tests for calendar page', async function() {
   let browser;
   let page;
   beforeEach(async() => {
-    browser = await puppeteer.launch({headless: true});
+    browser = await puppeteer.launch({headless: false,  args: ['--no-sandbox', '--disable-setuid-sandbox']});
     page =  await browser.newPage();
     try {
       await page.goto('http://localhost:3000/', {waitUntil: 'networkidle2'});

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "puppeteer": "^1.0.0"
   },
   "scripts": {
-    "test": "./node_modules/mocha/bin/mocha browser-tests"
+    "test": "node ./app.js && ./node_modules/mocha/bin/mocha browser-tests"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This commit runs the headless chrome in a sandboxed environment as
it's an opaque binary and can execute arbitrary code. This doesn't
play well with the continuous integration server, therefore, we need
to sandbox it